### PR TITLE
Include mocha global for jshint linter and fix `use strict` error with chai.js

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,5 +31,6 @@
   "white": false,
   "eqnull": true,
   "esnext": true,
-  "unused": true
+  "unused": true,
+  "mocha": true
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, exclude: '/node_modules/', loader: 'babel-loader' },
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
       { test: /\.css$/, loader: "style!css" },
       { test: /\.scss$/, loader: "style!css!sass" }
     ]


### PR DESCRIPTION
This makes it so that you don't get stuck with

``` sh
'describe' is not defined.
'it' is not defined.
...
```

When using jshint in the test files. Jasmine may also be a valuable option here to include.
